### PR TITLE
Added custom fetch callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Link Tool supports these configuration parameters:
 | ---------|-------------|------------------------------------------------|
 | endpoint | `string`    | **Required:** the endpoint for link data fetching. |
 | headers | `object`    | **Optional:** the headers used in the GET request. |
+| doFetch | `callback`  | **Optional:** the callback for custom fetch implementation `({url, endpoin, heaers}) => {}` |
 
 ## Output data
 

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ export default class LinkTool {
     this.config = {
       endpoint: config.endpoint || '',
       headers: config.headers || {},
-      doFetch: config.doFetch || null
+      doFetch: config.doFetch || null,
     };
 
     this.nodes = {
@@ -392,11 +392,15 @@ export default class LinkTool {
     this.data = { link: url };
 
     try {
-      const { body } = this.config.doFetch ?
-        await this.config.doFetch(
-          {url, endpoint: this.config.endpoint, headers: this.config.headers}
-          ) :
-        await (ajax.get({
+      const { body } = this.config.doFetch
+        ? await this.config.doFetch(
+          {
+            url,
+            endpoint: this.config.endpoint,
+            headers: this.config.headers,
+          }
+        )
+        : await (ajax.get({
           url: this.config.endpoint,
           headers: this.config.headers,
           data: {

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,7 @@ export default class LinkTool {
     this.config = {
       endpoint: config.endpoint || '',
       headers: config.headers || {},
+      doFetch: config.doFetch || null
     };
 
     this.nodes = {
@@ -391,13 +392,17 @@ export default class LinkTool {
     this.data = { link: url };
 
     try {
-      const { body } = await (ajax.get({
-        url: this.config.endpoint,
-        headers: this.config.headers,
-        data: {
-          url,
-        },
-      }));
+      const { body } = this.config.doFetch ?
+        await this.config.doFetch(
+          {url, endpoint: this.config.endpoint, headers: this.config.headers}
+          ) :
+        await (ajax.get({
+          url: this.config.endpoint,
+          headers: this.config.headers,
+          data: {
+            url,
+          },
+        }));
 
       this.onFetch(body);
     } catch (error) {


### PR DESCRIPTION
Add support for custom fetch. For example: `doFetch: async ((url, endpoint, headers}) => { return await axios.post(....) }`. 