### PR TITLE
Feat: auto-create the link block when a non-image link is pasted

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ const editor = EditorJS({
       class: LinkTool,
       config: {
         endpoint: 'http://localhost:8008/fetchUrl', // Your backend endpoint for url data fetching,
+        createOnPaste: true, // true to catch non-image pasted links and create a preview automatically
+        key: 'linkTool', // Required if createOnPaste is true - must match the tool key
       }
     }
   },
@@ -71,6 +73,8 @@ Link Tool supports these configuration parameters:
 | ---------|-------------|------------------------------------------------|
 | endpoint | `string`    | **Required:** the endpoint for link data fetching. |
 | headers | `object`    | **Optional:** the headers used in the GET request. |
+| createOnPaste | `boolean`    | **Optional:** true to catch non-image pasted links and create a preview automatically. |
+| key | `string`    | **Optional:** Required if createOnPaste is true - must match the tool key. |
 
 ## Output data
 

--- a/src/index.css
+++ b/src/index.css
@@ -70,32 +70,12 @@
     color: initial !important;
     text-decoration: none !important;
 
-    /* display: block;
-    padding: 25px;
-    border-radius: 2px;
-    box-shadow: 0 0 0 2px #fff;
-    color: initial !important;
-    text-decoration: none !important;
-
-    &::after {
-      content: "";
-      clear: both;
-      display: table;
-    } */
-
     &--rendered {
       background: #fff;
       border: 1px solid #E9E9E9;
       border-radius: 5px;
       will-change: filter;
       animation: link-in 450ms 1 cubic-bezier(0.215, 0.61, 0.355, 1);
-
-      /* background: #fff;
-      border: 1px solid rgba(201, 201, 204, 0.48);
-      box-shadow: 0 1px 3px rgba(0,0,0, .1);
-      border-radius: 6px;
-      will-change: filter;
-      animation: link-in 450ms 1 cubic-bezier(0.215, 0.61, 0.355, 1); */
 
       &:hover {
         box-shadow: 0 0 3px rgba(0,0,0, .16);
@@ -111,12 +91,6 @@
     height: 80px;
     aspect-ratio: 1/1;
     border-radius: 5px;
-
-    /* margin: 0 0 0 30px;
-    width: 65px;
-    height: 65px;
-    border-radius: 3px;
-    float: right; */
   }
 
   &__infos {
@@ -130,15 +104,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-
-    /* font-size: 17px;
-    font-weight: 600;
-    line-height: 1.5em;
-    margin: 0 0 10px 0;
-
-    + ^&__anchor {
-      margin-top: 25px;
-    } */
   }
 
   &__description {
@@ -150,14 +115,6 @@
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
-
-    /* margin: 0 0 20px 0;
-    font-size: 15px;
-    line-height: 1.55em;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden; */
   }
 
   &__anchor {
@@ -166,13 +123,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-
-    /* display: block;
-    font-size: 15px;
-    line-height: 1em;
-    color: #888 !important;
-    border: 0 !important;
-    padding: 0 !important; */
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,7 @@
 
   &__description {
     font-size: 13px;
+    color: #595959;
     line-height: 1.25;
     height:2rem;
     overflow: hidden;

--- a/src/index.css
+++ b/src/index.css
@@ -63,7 +63,14 @@
   }
 
   &__content {
-    display: block;
+    display: flex;
+    column-gap: 10px;
+    padding: 10px;
+    border-radius: 5px;
+    color: initial !important;
+    text-decoration: none !important;
+
+    /* display: block;
     padding: 25px;
     border-radius: 2px;
     box-shadow: 0 0 0 2px #fff;
@@ -74,15 +81,21 @@
       content: "";
       clear: both;
       display: table;
-    }
+    } */
 
     &--rendered {
       background: #fff;
+      border: 1px solid #E9E9E9;
+      border-radius: 5px;
+      will-change: filter;
+      animation: link-in 450ms 1 cubic-bezier(0.215, 0.61, 0.355, 1);
+
+      /* background: #fff;
       border: 1px solid rgba(201, 201, 204, 0.48);
       box-shadow: 0 1px 3px rgba(0,0,0, .1);
       border-radius: 6px;
       will-change: filter;
-      animation: link-in 450ms 1 cubic-bezier(0.215, 0.61, 0.355, 1);
+      animation: link-in 450ms 1 cubic-bezier(0.215, 0.61, 0.355, 1); */
 
       &:hover {
         box-shadow: 0 0 3px rgba(0,0,0, .16);
@@ -94,41 +107,71 @@
     background-position: center center;
     background-repeat: no-repeat;
     background-size: cover;
-    margin: 0 0 0 30px;
+    min-width: 80px;
+    height: 80px;
+    aspect-ratio: 1/1;
+    border-radius: 5px;
+
+    /* margin: 0 0 0 30px;
     width: 65px;
     height: 65px;
     border-radius: 3px;
-    float: right;
+    float: right; */
+  }
+
+  &__infos {
+    overflow: hidden;
+    flex: 1;
   }
 
   &__title {
-    font-size: 17px;
+    font-size: 15px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    /* font-size: 17px;
     font-weight: 600;
     line-height: 1.5em;
     margin: 0 0 10px 0;
 
     + ^&__anchor {
       margin-top: 25px;
-    }
+    } */
   }
 
   &__description {
-    margin: 0 0 20px 0;
+    font-size: 13px;
+    line-height: 1.25;
+    height:2rem;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+
+    /* margin: 0 0 20px 0;
     font-size: 15px;
     line-height: 1.55em;
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
-    overflow: hidden;
+    overflow: hidden; */
   }
 
   &__anchor {
-    display: block;
+    font-size: 13px;
+    color: #F44545;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    /* display: block;
     font-size: 15px;
     line-height: 1em;
     color: #888 !important;
     border: 0 !important;
-    padding: 0 !important;
+    padding: 0 !important; */
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -126,15 +126,16 @@
 
   &.highlight {
     .link-tool {
-      &&__content {
+      &__content {
         flex-direction: column;
       }
 
-      &&__image {
-      flex-direction: column;
-      width: 100%;
-      height: auto;
-      aspect-ratio: 4/3;
+      &__image {
+        flex-direction: column;
+        width: 100%;
+        height: auto;
+        aspect-ratio: 4/3;
+      }
     }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -19,12 +19,12 @@
           background-color: #fff3f6;
           border-color: #f3e0e0;
           color: #a95a5a;
-          box-shadow: inset 0 1px 3px 0 rgba(146, 62, 62, .05);
+          box-shadow: inset 0 1px 3px 0 rgba(146, 62, 62, 0.05);
         }
       }
     }
 
-    &[contentEditable=true][data-placeholder]::before{
+    &[contentEditable="true"][data-placeholder]::before {
       position: absolute;
       content: attr(data-placeholder);
       color: #707684;
@@ -32,15 +32,14 @@
       opacity: 0;
     }
 
-    &[contentEditable=true][data-placeholder]:empty {
-
+    &[contentEditable="true"][data-placeholder]:empty {
       &::before {
         opacity: 1;
       }
 
       &:focus::before {
-         opacity: 0;
-       }
+        opacity: 0;
+      }
     }
   }
 
@@ -72,13 +71,13 @@
 
     &--rendered {
       background: #fff;
-      border: 1px solid #E9E9E9;
+      border: 1px solid #e9e9e9;
       border-radius: 5px;
       will-change: filter;
       animation: link-in 450ms 1 cubic-bezier(0.215, 0.61, 0.355, 1);
 
       &:hover {
-        box-shadow: 0 0 3px rgba(0,0,0, .16);
+        box-shadow: 0 0 3px rgba(0, 0, 0, 0.16);
       }
     }
   }
@@ -110,7 +109,7 @@
     font-size: 13px;
     color: #595959;
     line-height: 1.25;
-    height:2rem;
+    height: 2rem;
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
@@ -119,10 +118,19 @@
 
   &__anchor {
     font-size: 13px;
-    color: #F44545;
+    color: #f44545;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  &.highlight {
+    .link-tool__image {
+      flex-direction: column;
+      width: 100%;
+      height: auto;
+      aspect-ratio: 4/3;
+    }
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -125,7 +125,12 @@
   }
 
   &.highlight {
-    .link-tool__image {
+    .link-tool {
+      &&__content {
+        flex-direction: column;
+      }
+
+      &&__image {
       flex-direction: column;
       width: 100%;
       height: auto;

--- a/src/index.js
+++ b/src/index.js
@@ -609,6 +609,7 @@ export default class LinkTool {
 
         if (tune.name === 'urlOnly') {
           this.replaceBlockWithParagraph();
+          this.api.toolbar.toggleBlockSettings(false);
         }
       },
     }));

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,7 @@ export default class LinkTool {
       inputHolder: null,
       linkContent: null,
       linkImage: null,
+      linkInfos: null,
       linkTitle: null,
       linkDescription: null,
       linkText: null,
@@ -155,6 +156,7 @@ export default class LinkTool {
   render() {
     this.nodes.wrapper = this.make('div', this.CSS.baseClass);
     this.nodes.container = this.make('div', this.CSS.container);
+    this.nodes.container = this.make('div', [this.CSS.container, 'not-prose']);
 
     this.nodes.inputHolder = this.makeInputHolder();
     this.nodes.linkContent = this.prepareLinkPreview();
@@ -164,7 +166,8 @@ export default class LinkTool {
      */
     if (Object.keys(this.data.meta).length) {
       this.nodes.container.appendChild(this.nodes.linkContent);
-      this.showLinkPreview(this.data.meta);
+      this.showLinkPreviewOverridden(this.data.meta);
+      // this.showLinkPreview(this.data.meta);
     } else {
       this.nodes.container.appendChild(this.nodes.inputHolder);
     }
@@ -239,6 +242,7 @@ export default class LinkTool {
       linkContent: 'link-tool__content',
       linkContentRendered: 'link-tool__content--rendered',
       linkImage: 'link-tool__image',
+      linkInfos: 'link-tool__infos',
       linkTitle: 'link-tool__title',
       linkDescription: 'link-tool__description',
       linkText: 'link-tool__anchor',
@@ -353,6 +357,7 @@ export default class LinkTool {
     });
 
     this.nodes.linkImage = this.make('div', this.CSS.linkImage);
+    this.nodes.linkInfos = this.make('div', this.CSS.linkInfos);
     this.nodes.linkTitle = this.make('div', this.CSS.linkTitle);
     this.nodes.linkDescription = this.make('p', this.CSS.linkDescription);
     this.nodes.linkText = this.make('span', this.CSS.linkText);
@@ -392,6 +397,37 @@ export default class LinkTool {
     } catch (e) {
       this.nodes.linkText.textContent = this.data.link;
     }
+  }
+
+  /**
+   * Compose link preview from fetched data
+   *
+   * @param {metaData} meta - link meta data
+   */
+  showLinkPreviewOverridden({ image, title, description }) {
+    this.nodes.container.appendChild(this.nodes.linkContent);
+
+    if (image && image.url) {
+      this.nodes.linkImage.style.backgroundImage = 'url(' + image.url + ')';
+      this.nodes.linkContent.appendChild(this.nodes.linkImage);
+    }
+
+    if (title) {
+      this.nodes.linkTitle.textContent = title;
+      this.nodes.linkInfos.appendChild(this.nodes.linkTitle);
+    }
+
+    if (description) {
+      this.nodes.linkDescription.textContent = description;
+      this.nodes.linkInfos.appendChild(this.nodes.linkDescription);
+    }
+
+    this.nodes.linkText.textContent = this.data.link;
+    this.nodes.linkInfos.appendChild(this.nodes.linkText);
+
+    this.nodes.linkContent.classList.add(this.CSS.linkContentRendered);
+    this.nodes.linkContent.setAttribute('href', this.data.link);
+    this.nodes.linkContent.appendChild(this.nodes.linkInfos);
   }
 
   /**
@@ -502,7 +538,8 @@ export default class LinkTool {
 
     this.hideProgress().then(() => {
       this.nodes.inputHolder.remove();
-      this.showLinkPreview(metaData);
+      this.showLinkPreviewOverridden(metaData);
+      // this.showLinkPreview(metaData);
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -562,6 +562,9 @@ export default class LinkTool {
     const pluginName = this.getPluginName();
 
     this.api.blocks.insert(pluginName, { link }, undefined, this.api.blocks.getCurrentBlockIndex(), true, true);
+    setTimeout(() => {
+      this.api.toolbar.toggleBlockSettings(true);
+    });
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -166,8 +166,7 @@ export default class LinkTool {
      */
     if (Object.keys(this.data.meta).length) {
       this.nodes.container.appendChild(this.nodes.linkContent);
-      this.showLinkPreviewOverridden(this.data.meta);
-      // this.showLinkPreview(this.data.meta);
+      this.showLinkPreview(this.data.meta);
     } else {
       this.nodes.container.appendChild(this.nodes.inputHolder);
     }
@@ -380,40 +379,6 @@ export default class LinkTool {
 
     if (title) {
       this.nodes.linkTitle.textContent = title;
-      this.nodes.linkContent.appendChild(this.nodes.linkTitle);
-    }
-
-    if (description) {
-      this.nodes.linkDescription.textContent = description;
-      this.nodes.linkContent.appendChild(this.nodes.linkDescription);
-    }
-
-    this.nodes.linkContent.classList.add(this.CSS.linkContentRendered);
-    this.nodes.linkContent.setAttribute('href', this.data.link);
-    this.nodes.linkContent.appendChild(this.nodes.linkText);
-
-    try {
-      this.nodes.linkText.textContent = new URL(this.data.link).hostname;
-    } catch (e) {
-      this.nodes.linkText.textContent = this.data.link;
-    }
-  }
-
-  /**
-   * Compose link preview from fetched data
-   *
-   * @param {metaData} meta - link meta data
-   */
-  showLinkPreviewOverridden({ image, title, description }) {
-    this.nodes.container.appendChild(this.nodes.linkContent);
-
-    if (image && image.url) {
-      this.nodes.linkImage.style.backgroundImage = 'url(' + image.url + ')';
-      this.nodes.linkContent.appendChild(this.nodes.linkImage);
-    }
-
-    if (title) {
-      this.nodes.linkTitle.textContent = title;
       this.nodes.linkInfos.appendChild(this.nodes.linkTitle);
     }
 
@@ -538,8 +503,7 @@ export default class LinkTool {
 
     this.hideProgress().then(() => {
       this.nodes.inputHolder.remove();
-      this.showLinkPreviewOverridden(metaData);
-      // this.showLinkPreview(metaData);
+      this.showLinkPreview(metaData);
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -450,6 +450,7 @@ export default class LinkTool {
     const newBlock = this.api.blocks.insert('paragraph', { text: this.nodes.input.textContent }, undefined, this.api.blocks.getCurrentBlockIndex(), true, true);
 
     this.api.caret.setToBlock(newBlock.id);
+    this.api.toolbar.toggleBlockSettings(false);
   }
 
   /**
@@ -609,7 +610,6 @@ export default class LinkTool {
 
         if (tune.name === 'urlOnly') {
           this.replaceBlockWithParagraph();
-          this.api.toolbar.toggleBlockSettings(false);
         }
       },
     }));

--- a/src/videoLink.js
+++ b/src/videoLink.js
@@ -4,6 +4,7 @@ const videoLinkRegex = {
   vimeo:
     /(?:http[s]?:\/\/)?(?:www.)?(?:player.)?vimeo\.co(?:.+\/([^\/]\d+)(?:#t=[\d]+)?s?$)/,
   youtube: /(?:https?:\/\/)?(?:www\.)?(?:(?:youtu\.be\/)|(?:youtube\.com)\/(?:v\/|u\/\w\/|embed\/|watch))(?:(?:\?v=)?([^#&?=]*))?((?:[?&]\w*=\w*)*)/,
+  dailymotion: /(?:https?:\/\/)?(?:www\.)?dailymotion\.com\/video\/([^_]+)/,
   coub: /https?:\/\/coub\.com\/view\/([^\/\?\&]+)/,
   vine: /https?:\/\/vine\.co\/v\/([^\/\?\&]+)/,
   imgur: /https?:\/\/(?:i\.)?imgur\.com.*\/([a-zA-Z0-9]+)(?:\.gifv)?/,

--- a/src/videoLink.js
+++ b/src/videoLink.js
@@ -1,0 +1,27 @@
+/* eslint-disable */
+
+const videoLinkRegex = {
+  vimeo:
+    /(?:http[s]?:\/\/)?(?:www.)?(?:player.)?vimeo\.co(?:.+\/([^\/]\d+)(?:#t=[\d]+)?s?$)/,
+  youtube: /(?:https?:\/\/)?(?:www\.)?(?:(?:youtu\.be\/)|(?:youtube\.com)\/(?:v\/|u\/\w\/|embed\/|watch))(?:(?:\?v=)?([^#&?=]*))?((?:[?&]\w*=\w*)*)/,
+  coub: /https?:\/\/coub\.com\/view\/([^\/\?\&]+)/,
+  vine: /https?:\/\/vine\.co\/v\/([^\/\?\&]+)/,
+  imgur: /https?:\/\/(?:i\.)?imgur\.com.*\/([a-zA-Z0-9]+)(?:\.gifv)?/,
+  gfycat: /https?:\/\/gfycat\.com(?:\/detail)?\/([a-zA-Z]+)/,
+  'twitch-channel': /https?:\/\/www\.twitch\.tv\/([^\/\?\&]*)\/?$/,
+  'twitch-video': /https?:\/\/www\.twitch\.tv\/(?:[^\/\?\&]*\/v|videos)\/([0-9]*)/,
+  'yandex-music-album': /https?:\/\/music\.yandex\.ru\/album\/([0-9]*)\/?$/,
+  'yandex-music-track': /https?:\/\/music\.yandex\.ru\/album\/([0-9]*)\/track\/([0-9]*)/,
+  'yandex-music-playlist': /https?:\/\/music\.yandex\.ru\/users\/([^\/\?\&]*)\/playlists\/([0-9]*)/,
+  codepen: /https?:\/\/codepen\.io\/([^\/\?\&]*)\/pen\/([^\/\?\&]*)/,
+  instagram: /https?:\/\/www\.instagram\.com\/p\/([^\/\?\&]+)\/?.*/,
+  twitter: /^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(?:es)?\/(\d+?.*)?$/,
+  pinterest: /https?:\/\/([^\/\?\&]*).pinterest.com\/pin\/([^\/\?\&]*)\/?$/,
+  facebook: /https?:\/\/www.facebook.com\/([^\/\?\&]*)\/(.*)/,
+  aparat: /(?:http[s]?:\/\/)?(?:www.)?aparat\.com\/v\/([^\/\?\&]+)\/?/,
+  miro: /https:\/\/miro.com\/\S+(\S{12})\/(\S+)?/,
+  github: /https?:\/\/gist.github.com\/([^\/\?\&]*)\/([^\/\?\&]*)/,
+};
+
+export const isVideoLink = (string) =>
+  Object.values(videoLinkRegex).some((videoRegex) => videoRegex.test(string));


### PR DESCRIPTION
Here is a feature I need for my project, and I thought it would be good to suggest a merge in the main repo.

Use case: when users paste links in the editor, in an empty paragraph, it should automatically attempt to create a link block.

It may introduce a couple of UX issues, so I also changed:

- if the auto-link fails, it falls back to replacing the failed link with a paragraph with the raw link (only for auto-links, not for user-created link blocks)
- a tune has been added: replace the embed with a raw link, in case the user's attempt was not to create a link block.
- Those behaviors are only enabled if the auto-link is enabled.

Improvements I've identified, but I don't know how to do them:

- [ ] I added 2 configs. In the second one, the user should repeat the plugin key, just because I wasn't able to get it dynamically in the plugin code (any idea about how to do that?)
- [x] When the URL is pasted and the block created, auto-show the tune menu

If you have any suggestions for them, I would be happy to improve the code.